### PR TITLE
Refactorings

### DIFF
--- a/core/src/main/scala/com/github/rvanheest/spickle/parser/Parser.scala
+++ b/core/src/main/scala/com/github/rvanheest/spickle/parser/Parser.scala
@@ -432,4 +432,56 @@ object Parser {
      */
     def toDouble: Parser[State, Double] = parser.map(_.toDouble)
   }
+
+  /**
+   * Enriches the API for parsers that parse a token to a `Option[String]`. This class contains some
+   * convenience methods that make programming a complex parser a little easier.
+   *
+   * @param parser the parser to be enriched
+   * @tparam State the type of tokens to be parsed by the given parser
+   */
+  implicit class MaybeStringOperators[State](val parser: Parser[State, Option[String]]) extends AnyVal {
+
+    /**
+     * Convert the result of this parse to a `Option[Byte]`
+     *
+     * @return a new parser that converts the result of a parse to a `Option[Byte]`
+     */
+    def toByte: Parser[State, Option[Byte]] = parser.map(_.map(_.toByte))
+
+    /**
+     * Convert the result of this parse to a `Option[Short]`
+     *
+     * @return a new parser that converts the result of a parse to a `Option[Short]`
+     */
+    def toShort: Parser[State, Option[Short]] = parser.map(_.map(_.toShort))
+
+    /**
+     * Convert the result of this parse to a `Option[Int]`
+     *
+     * @return a new parser that converts the result of a parse to a `Option[Int]`
+     */
+    def toInt: Parser[State, Option[Int]] = parser.map(_.map(_.toInt))
+
+    /**
+     * Convert the result of this parse to a `Option[Long]`
+     *
+     * @return a new parser that converts the result of a parse to a `Option[Long]`
+     */
+    def toLong: Parser[State, Option[Long]] = parser.map(_.map(_.toLong))
+
+    /**
+     * Convert the result of this parse to a `Option[Float]`
+     *
+     * @return a new parser that converts the result of a parse to a `Option[Float]`
+     */
+    def toFloat: Parser[State, Option[Float]] = parser.map(_.map(_.toFloat))
+
+    /**
+     * Convert the result of this parse to a `Double]`
+     *
+     * @return a new parser that converts the result of a parse to a `Double]`
+     */
+    def toDouble: Parser[State, Option[Double]] = parser.map(_.map(_.toDouble))
+  }
 }

--- a/core/src/main/scala/com/github/rvanheest/spickle/parser/xml/XmlParser.scala
+++ b/core/src/main/scala/com/github/rvanheest/spickle/parser/xml/XmlParser.scala
@@ -35,9 +35,7 @@ object XmlParser {
 
   def branchNode[A](name: String)(subParser: XmlParser[A]): XmlParser[A] = {
     Parser(node(name).map(_.child).parse(_) match {
-      case (Success(childNodes), rest) =>
-        val (r, rest2) = subParser.parse(childNodes)
-        (r, rest2 ++ rest)
+      case (Success(childNodes), rest) => (subParser.eval(childNodes), rest)
       case (Failure(e), rest) => (Failure(e), rest)
     })
   }

--- a/core/src/main/scala/com/github/rvanheest/spickle/pickle/Pickle.scala
+++ b/core/src/main/scala/com/github/rvanheest/spickle/pickle/Pickle.scala
@@ -31,7 +31,7 @@ class Pickle[State, A](private[pickle] val serializer: Serializer[State, A],
   def orElse(other: => Pickle[State, A]): Pickle[State, A] = {
     Pickle(
       serializer = this.serializer orElse other.serializer,
-      parser = this.parser <|> other.parser
+      parser = this.parser orElse other.parser
     )
   }
 

--- a/core/src/main/scala/com/github/rvanheest/spickle/pickle/Pickle.scala
+++ b/core/src/main/scala/com/github/rvanheest/spickle/pickle/Pickle.scala
@@ -3,7 +3,7 @@ package com.github.rvanheest.spickle.pickle
 import com.github.rvanheest.spickle.parser.Parser
 import com.github.rvanheest.spickle.serializer.Serializer
 
-import scala.reflect.{ ClassTag, classTag }
+import scala.reflect.ClassTag
 import scala.util.Try
 
 class Pickle[State, A](private[pickle] val serializer: Serializer[State, A],
@@ -21,7 +21,7 @@ class Pickle[State, A](private[pickle] val serializer: Serializer[State, A],
 
   def seqId: SeqBuilder[State, A, A] = new SeqBuilder(this, identity)
 
-  def upcast[B >: A](implicit ctA: ClassTag[A], ctB: ClassTag[B]): Pickle[State, B] = {
+  def upcast[B >: A](implicit ctA: ClassTag[A]): Pickle[State, B] = {
     Pickle(
       serializer = serializer.upcast[B],
       parser = parser.map(identity)

--- a/core/src/main/scala/com/github/rvanheest/spickle/pickle/Pickle.scala
+++ b/core/src/main/scala/com/github/rvanheest/spickle/pickle/Pickle.scala
@@ -149,4 +149,18 @@ object Pickle {
 
     def toDouble: Pickle[State, Double] = pickle.seq[Double](_.toString).map(_.toDouble)
   }
+
+  implicit class MaybeStringOperators[State](val pickle: Pickle[State, Option[String]]) extends AnyVal {
+    def toByte: Pickle[State, Option[Byte]] = pickle.seq[Option[Byte]](_.map(_.toString)).map(_.map(_.toByte))
+
+    def toShort: Pickle[State, Option[Short]] = pickle.seq[Option[Short]](_.map(_.toString)).map(_.map(_.toShort))
+
+    def toInt: Pickle[State, Option[Int]] = pickle.seq[Option[Int]](_.map(_.toString)).map(_.map(_.toInt))
+
+    def toLong: Pickle[State, Option[Long]] = pickle.seq[Option[Long]](_.map(_.toString)).map(_.map(_.toLong))
+
+    def toFloat: Pickle[State, Option[Float]] = pickle.seq[Option[Float]](_.map(_.toString)).map(_.map(_.toFloat))
+
+    def toDouble: Pickle[State, Option[Double]] = pickle.seq[Option[Double]](_.map(_.toString)).map(_.map(_.toDouble))
+  }
 }

--- a/core/src/main/scala/com/github/rvanheest/spickle/serializer/Serializer.scala
+++ b/core/src/main/scala/com/github/rvanheest/spickle/serializer/Serializer.scala
@@ -142,4 +142,19 @@ object Serializer {
 
     def fromDouble: Serializer[State, Double] = serializer.contramap(_.toString)
   }
+
+  implicit class MaybeStringOperators[State](val serializer: Serializer[State, Option[String]]) extends AnyVal {
+
+    def fromByte: Serializer[State, Option[Byte]] = serializer.contramap(_.map(_.toString))
+
+    def fromShort: Serializer[State, Option[Short]] = serializer.contramap(_.map(_.toString))
+
+    def fromInt: Serializer[State, Option[Int]] = serializer.contramap(_.map(_.toString))
+
+    def fromLong: Serializer[State, Option[Long]] = serializer.contramap(_.map(_.toString))
+
+    def fromFloat: Serializer[State, Option[Float]] = serializer.contramap(_.map(_.toString))
+
+    def fromDouble: Serializer[State, Option[Double]] = serializer.contramap(_.map(_.toString))
+  }
 }

--- a/core/src/main/scala/com/github/rvanheest/spickle/serializer/Serializer.scala
+++ b/core/src/main/scala/com/github/rvanheest/spickle/serializer/Serializer.scala
@@ -31,7 +31,7 @@ class Serializer[State, A](private[serializer] val serializer: (A, State) => Try
     })
   }
 
-  def upcast[B >: A](implicit ctA: ClassTag[A], ctB: ClassTag[B]): Serializer[State, B] = {
+  def upcast[B >: A](implicit ctA: ClassTag[A]): Serializer[State, B] = {
     this.contramap {
       case a: A => a
       case x => throw SerializerFailedException(s"can't cast ${ x.getClass } to ${ classTag[A] }")

--- a/core/src/test/scala/com/github/rvanheest/spickle/test/parser/xml/XmlParserTest.scala
+++ b/core/src/test/scala/com/github/rvanheest/spickle/test/parser/xml/XmlParserTest.scala
@@ -91,7 +91,7 @@ class XmlParserTest extends FlatSpec with Matchers with Inside {
     } yield bars.mkString(" ")
 
     branchNode("foo")(subParser).parse(Utility.trim(input)) should matchPattern {
-      case (Success("hello world"), Seq(<baz>!</baz>)) =>
+      case (Success("hello world"), Nil) =>
     }
   }
 
@@ -104,9 +104,9 @@ class XmlParserTest extends FlatSpec with Matchers with Inside {
         <baz>!</baz>
       </foo>,
       <foo>
-        <bar>hello</bar>
-        <bar>world</bar>
-        <baz>!</baz>
+        <bar>hello2</bar>
+        <bar>world2</bar>
+        <baz>!2</baz>
       </foo>
       // @formatter:on
     )
@@ -117,7 +117,7 @@ class XmlParserTest extends FlatSpec with Matchers with Inside {
 
     branchNode("foo")(subParser).parse(input map Utility.trim) should matchPattern {
       // @formatter:off
-      case (Success("hello world"), Seq(<baz>!</baz>, <foo><bar>hello</bar><bar>world</bar><baz>!</baz></foo>)) =>
+      case (Success("hello world"), Seq(<foo><bar>hello2</bar><bar>world2</bar><baz>!2</baz></foo>)) =>
       // flattened structure in second foo is intentional; this was flattened in the Utility.trim above
       // @formatter:on
     }

--- a/example/src/main/scala/com/github/rvanheest/spickle/example/xml/person/PersonParser.scala
+++ b/example/src/main/scala/com/github/rvanheest/spickle/example/xml/person/PersonParser.scala
@@ -14,7 +14,7 @@ trait PersonParser {
     } yield Number(number, addition)
   }
 
-  def parseRealAddress(name: String): XmlParser[Address] = {
+  def parseRealAddress(name: String): XmlParser[RealAddress] = {
     for {
       // no attributes here
       address <- branchNode(name) {
@@ -28,7 +28,7 @@ trait PersonParser {
     } yield address
   }
 
-  def parseFreepostAddress(name: String): XmlParser[Address] = {
+  def parseFreepostAddress(name: String): XmlParser[FreepostAddress] = {
     for {
       // no attributes here
       address <- branchNode(name) {
@@ -46,7 +46,7 @@ trait PersonParser {
   }
 
   def parsePerson: XmlParser[Person] = {
-    implicit val xlinkNamespace = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
+    implicit val xlinkNamespace: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
     for {
       age <- attribute("age").toInt
       _ <- namespaceAttribute("age").toInt


### PR DESCRIPTION
* improve `orElse` operator in `Parser`
* remove unnecessary `TypeTag[B]` from `upcast` operators
* enrich `Parser`, `Serializer` and `Pickler` with number conversions for `Option[String]`
* discard the remaining nodes inside a `XmlParser.branchNode`