### PR TITLE
XML namespace operators

### DIFF
--- a/core/src/main/scala/com/github/rvanheest/spickle/parser/xml/XmlParser.scala
+++ b/core/src/main/scala/com/github/rvanheest/spickle/parser/xml/XmlParser.scala
@@ -33,7 +33,7 @@ object XmlParser {
         (Success(head), tail)
       case (head, tail) =>
         val msg = namespace
-          .map(ns => s"could not find an element with name '$name' and namespace '${ns.toString.trim}'")
+          .map(ns => s"could not find an element with name '$name' and namespace '${ ns.toString.trim }'")
           .getOrElse(s"could not find an element with name '$name'")
         (Failure(ParserFailedException(msg)), head +: tail)
     }

--- a/core/src/main/scala/com/github/rvanheest/spickle/parser/xml/XmlParser.scala
+++ b/core/src/main/scala/com/github/rvanheest/spickle/parser/xml/XmlParser.scala
@@ -54,7 +54,7 @@ object XmlParser {
       .satisfy(_.nonEmpty, _ => s"attribute '$attr' is not found or is empty")
   }
 
-  def namespaceAttribute(attr: String)(implicit namespace: NamespaceBinding): XmlParser[String] = {
+  def attribute(attr: String, namespace: NamespaceBinding): XmlParser[String] = {
     // notice that _.attributes(...) can be null!!!
     attributeItem
       .map(_.attributes(namespace.uri, namespace, attr))

--- a/core/src/main/scala/com/github/rvanheest/spickle/pickle/xml/XmlPickle.scala
+++ b/core/src/main/scala/com/github/rvanheest/spickle/pickle/xml/XmlPickle.scala
@@ -52,10 +52,10 @@ object XmlPickle {
     )
   }
 
-  def namespaceAttribute(name: String)(implicit namespace: NamespaceBinding): XmlPickle[String] = {
+  def attribute(name: String, namespace: NamespaceBinding): XmlPickle[String] = {
     Pickle(
-      serializer = XmlSerializer.namespaceAttribute(name),
-      parser = XmlParser.namespaceAttribute(name)
+      serializer = XmlSerializer.attribute(name, namespace),
+      parser = XmlParser.attribute(name, namespace)
     )
   }
 

--- a/core/src/main/scala/com/github/rvanheest/spickle/pickle/xml/XmlPickle.scala
+++ b/core/src/main/scala/com/github/rvanheest/spickle/pickle/xml/XmlPickle.scala
@@ -87,6 +87,13 @@ object XmlPickle {
     )
   }
 
+  def withNamespace[A](namespace: NamespaceBinding)(pickle: XmlPickle[A]): XmlPickle[A] = {
+    Pickle(
+      serializer = XmlSerializer.withNamespace(namespace)(pickle.serializer),
+      parser = pickle.parser // nothing to do here
+    )
+  }
+
   def fromAllMandatory[T](parser: XmlPickle[T]): AllPickleBuilder[T :: HNil] = {
     AllPickleBuilder.fromMandatory(parser)
   }

--- a/core/src/main/scala/com/github/rvanheest/spickle/pickle/xml/XmlPickle.scala
+++ b/core/src/main/scala/com/github/rvanheest/spickle/pickle/xml/XmlPickle.scala
@@ -24,10 +24,24 @@ object XmlPickle {
     )
   }
 
+  def emptyNode(name: String, namespace: NamespaceBinding): XmlPickle[Unit] = {
+    Pickle(
+      serializer = XmlSerializer.emptyNode(name, namespace),
+      parser = XmlParser.emptyNode(name, namespace)
+    )
+  }
+
   def node(name: String): XmlPickle[Node] = {
     Pickle(
       serializer = XmlSerializer.node(name),
       parser = XmlParser.node(name)
+    )
+  }
+
+  def node(name: String, namespace: NamespaceBinding): XmlPickle[Node] = {
+    Pickle(
+      serializer = XmlSerializer.node(name, namespace),
+      parser = XmlParser.node(name, namespace)
     )
   }
 
@@ -38,10 +52,24 @@ object XmlPickle {
     )
   }
 
+  def stringNode(name: String, namespace: NamespaceBinding): XmlPickle[String] = {
+    Pickle(
+      serializer = XmlSerializer.stringNode(name, namespace),
+      parser = XmlParser.stringNode(name, namespace)
+    )
+  }
+
   def branchNode[A](name: String)(pickleA: XmlPickle[A]): XmlPickle[A] = {
     Pickle(
       serializer = XmlSerializer.branchNode(name)(pickleA.serializer),
       parser = XmlParser.branchNode(name)(pickleA.parser)
+    )
+  }
+
+  def branchNode[A](name: String, namespace: NamespaceBinding)(pickleA: XmlPickle[A]): XmlPickle[A] = {
+    Pickle(
+      serializer = XmlSerializer.branchNode(name, namespace)(pickleA.serializer),
+      parser = XmlParser.branchNode(name, namespace)(pickleA.parser)
     )
   }
 

--- a/core/src/main/scala/com/github/rvanheest/spickle/serializer/xml/XmlSerializer.scala
+++ b/core/src/main/scala/com/github/rvanheest/spickle/serializer/xml/XmlSerializer.scala
@@ -44,7 +44,7 @@ object XmlSerializer {
     })
   }
 
-  def namespaceAttribute(name: String)(implicit namespace: NamespaceBinding): XmlSerializer[String] = {
+  def attribute(name: String, namespace: NamespaceBinding): XmlSerializer[String] = {
     Serializer((s: String, xml: Seq[Node]) => Try {
       xml.headOption map {
         case elem: Elem => elem % new PrefixedAttribute(namespace.prefix, name, s, Null) ++ xml.tail

--- a/core/src/main/scala/com/github/rvanheest/spickle/serializer/xml/XmlSerializer.scala
+++ b/core/src/main/scala/com/github/rvanheest/spickle/serializer/xml/XmlSerializer.scala
@@ -82,6 +82,13 @@ object XmlSerializer {
     })
   }
 
+  def withNamespace[A](namespace: NamespaceBinding)(serializerA: XmlSerializer[A]): XmlSerializer[A] = {
+    Serializer((a, xml) => serializerA.serialize(a).map(_.map {
+      case e: Elem => e.copy(scope = namespace)
+      case other => other
+    } ++ xml))
+  }
+
   def fromAllMandatory[T](serializer: XmlSerializer[T]): AllSerializerBuilder[T :: HNil] = {
     AllSerializerBuilder.fromMandatory(serializer)
   }

--- a/core/src/test/scala/com/github/rvanheest/spickle/test/XmlEquality.scala
+++ b/core/src/test/scala/com/github/rvanheest/spickle/test/XmlEquality.scala
@@ -1,0 +1,37 @@
+package com.github.rvanheest.spickle.test
+
+import org.scalatest.Suite
+import org.scalatest.matchers.{ MatchResult, Matcher }
+
+import scala.util.{ Failure, Success, Try }
+import scala.xml.{ Node, PrettyPrinter }
+
+trait XmlEquality {
+  this: Suite =>
+
+  class EqualTrimmedMatcher(right: Iterable[Node]) extends Matcher[Try[Iterable[Node]]] {
+    private val pp = new PrettyPrinter(160, 2)
+
+    private def prepForTest(n: Node): String = pp.format(n)
+
+    override def apply(left: Try[Iterable[Node]]): MatchResult = {
+      left match {
+        case Success(leftXml) =>
+          val prettyLeft = leftXml.map(prepForTest)
+          val prettyRight = right.map(prepForTest)
+
+          lazy val prettyLeftString = prettyLeft.mkString("\n")
+          lazy val prettyRightString = prettyRight.mkString("\n")
+
+          MatchResult(
+            prettyLeft == prettyRight,
+            s"$prettyLeftString was not equal to $prettyRightString",
+            s"$prettyLeftString was equal to $prettyRightString"
+          )
+        case Failure(e) =>
+          fail(e)
+      }
+    }
+  }
+  def equalTrimmed(right: Iterable[Node]) = new EqualTrimmedMatcher(right)
+}

--- a/core/src/test/scala/com/github/rvanheest/spickle/test/parser/xml/XmlParserTest.scala
+++ b/core/src/test/scala/com/github/rvanheest/spickle/test/parser/xml/XmlParserTest.scala
@@ -313,7 +313,7 @@ class XmlParserTest extends FlatSpec with Matchers with Inside {
 
   it should "fail when the parent parser is not fulfilled" in {
     val input = Utility.trim(
-    // @formatter:off
+      // @formatter:off
       <xlink:foo xmlns:xlink="http://www.w3.org/1999/xlink">
         <bar>hello</bar>
         <bar>world</bar>

--- a/core/src/test/scala/com/github/rvanheest/spickle/test/parser/xml/XmlParserTest.scala
+++ b/core/src/test/scala/com/github/rvanheest/spickle/test/parser/xml/XmlParserTest.scala
@@ -163,8 +163,8 @@ class XmlParserTest extends FlatSpec with Matchers with Inside {
     // @formatter:off
     val input = <foo xlink:type="simple" hello="abc">bar</foo>
     // @formatter:on
-    implicit val ns: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
-    namespaceAttribute("type").parse(input) should matchPattern {
+    val ns: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
+    attribute("type", ns).parse(input) should matchPattern {
       case (Success("simple"), `input`) =>
     }
   }
@@ -173,10 +173,10 @@ class XmlParserTest extends FlatSpec with Matchers with Inside {
     // @formatter:off
     val input = <foo ylink:type="simple" hello="abc">bar</foo>
     // @formatter:on
-    implicit val ns: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
+    val ns: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
     val expectedMsg = "attribute 'type' with namespace ' xmlns:xlink=\"http://www.w3.org/1999/xlink\"' is not found"
 
-    namespaceAttribute("type").parse(input) should matchPattern {
+    attribute("type", ns).parse(input) should matchPattern {
       case (Failure(ParserFailedException(`expectedMsg`)), `input`) =>
     }
   }
@@ -185,10 +185,10 @@ class XmlParserTest extends FlatSpec with Matchers with Inside {
     // @formatter:off
     val input = <foo hello="abc">bar</foo>
     // @formatter:on
-    implicit val ns: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
+    val ns: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
     val expectedMsg = "attribute 'type' with namespace ' xmlns:xlink=\"http://www.w3.org/1999/xlink\"' is not found"
 
-    namespaceAttribute("type").parse(input) should matchPattern {
+    attribute("type", ns).parse(input) should matchPattern {
       case (Failure(ParserFailedException(`expectedMsg`)), `input`) =>
     }
   }

--- a/core/src/test/scala/com/github/rvanheest/spickle/test/parser/xml/XmlParserTest.scala
+++ b/core/src/test/scala/com/github/rvanheest/spickle/test/parser/xml/XmlParserTest.scala
@@ -15,7 +15,6 @@ class XmlParserTest extends FlatSpec with Matchers with Inside {
 
   private val foo = <foo>test</foo>
   private val fooPf = <xlink:foo>test</xlink:foo>
-  private val fooNS = <xlink:foo xmlns:xlink="http://www.w3.org/1999/xlink">test</xlink:foo>
   private val bar = <bar/>
   private val barNS = <xlink:bar xmlns:xlink="http://www.w3.org/1999/xlink"/>
   private val baz = <baz>hello world</baz>

--- a/core/src/test/scala/com/github/rvanheest/spickle/test/pickle/xml/XmlPickleTest.scala
+++ b/core/src/test/scala/com/github/rvanheest/spickle/test/pickle/xml/XmlPickleTest.scala
@@ -391,11 +391,11 @@ class XmlPickleTest extends FlatSpec with Matchers with Inside with XmlEquality 
       <abc>test1</abc>,
       <abc>test2</abc>,
       <abc>test3</abc>,
-      <abc>test4</abc>
+      <abc>test4</abc>,
       <def>random1</def>,
       <ghi>random2</ghi>,
       <klm>random3</klm>,
-    ).flatten
+    )
     val pickle = collect(stringNode("abc"))
 
     inside(pickle.parse(input)) {
@@ -426,11 +426,11 @@ class XmlPickleTest extends FlatSpec with Matchers with Inside with XmlEquality 
       <abc>test1</abc>,
       <abc>test2</abc>,
       <abc>test3</abc>,
-      <abc>test4</abc>
+      <abc>test4</abc>,
       <def>random1</def>,
       <def>random3</def>,
       <ghi>random2</ghi>,
-    ).flatten
+    )
     type Output = (Seq[String], Seq[String])
     val pickle: XmlPickle[Output] = for {
       abcs <- collect(stringNode("abc")).seq[Output] { case (seq1, _) => seq1 }

--- a/core/src/test/scala/com/github/rvanheest/spickle/test/pickle/xml/XmlPickleTest.scala
+++ b/core/src/test/scala/com/github/rvanheest/spickle/test/pickle/xml/XmlPickleTest.scala
@@ -100,8 +100,8 @@ class XmlPickleTest extends FlatSpec with Matchers with Inside {
     val input = <foo hello="abc">bar</foo>
     val output = <foo xlink:type="simple" hello="abc">bar</foo>
     // @formatter:on
-    implicit val ns: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
-    namespaceAttribute("type").serialize("simple", input) should matchPattern {
+    val ns: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
+    attribute("type", ns).serialize("simple", input) should matchPattern {
       case Success(Seq(`output`)) =>
     }
   }
@@ -111,22 +111,22 @@ class XmlPickleTest extends FlatSpec with Matchers with Inside {
     val input = <foo xlink:type="abc" hello="abc">bar</foo>
     val output = <foo xlink:type="simple" hello="abc">bar</foo>
     // @formatter:on
-    implicit val ns: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
-    namespaceAttribute("type").serialize("simple", input) should matchPattern {
+    val ns: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
+    attribute("type", ns).serialize("simple", input) should matchPattern {
       case Success(Seq(`output`)) =>
     }
   }
 
   it should "fail when the state is empty" in {
-    implicit val ns: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
-    namespaceAttribute("type").serialize("simple") should matchPattern {
+    val ns: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
+    attribute("type", ns).serialize("simple") should matchPattern {
       case Failure(SerializerFailedException("Cannot add an attribute with name 'xlink:type' to an empty node sequence")) =>
     }
   }
 
   it should "fail if the first node in the state is not an element" in {
-    implicit val ns: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
-    namespaceAttribute("type").serialize("simple", Comment("hello")) should matchPattern {
+    val ns: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
+    attribute("type", ns).serialize("simple", Comment("hello")) should matchPattern {
       case Failure(SerializerFailedException("Can only add an attribute with name 'xlink:type' to elements: <!--hello-->")) =>
     }
   }

--- a/core/src/test/scala/com/github/rvanheest/spickle/test/pickle/xml/XmlPickleTest.scala
+++ b/core/src/test/scala/com/github/rvanheest/spickle/test/pickle/xml/XmlPickleTest.scala
@@ -251,7 +251,7 @@ class XmlPickleTest extends FlatSpec with Matchers with Inside with XmlEquality 
     inside(fooPickle.parse(input)) {
       case (Success(parsedResult), remainder) =>
         remainder shouldBe empty
-        parsedResult shouldBe (Some("blabla"), Some("albalb"))
+        parsedResult shouldBe(Some("blabla"), Some("albalb"))
 
         val resultXml = fooPickle.serialize(parsedResult, remainder)
         resultXml should equalTrimmed(input)
@@ -272,7 +272,7 @@ class XmlPickleTest extends FlatSpec with Matchers with Inside with XmlEquality 
     inside(fooPickle.parse(input)) {
       case (Success(parsedResult), remainder) =>
         remainder shouldBe empty
-        parsedResult shouldBe (Some("blabla"), "albalb")
+        parsedResult shouldBe(Some("blabla"), "albalb")
 
         val resultXml = fooPickle.serialize(parsedResult, remainder)
         resultXml should equalTrimmed(input)
@@ -293,7 +293,7 @@ class XmlPickleTest extends FlatSpec with Matchers with Inside with XmlEquality 
     inside(fooPickle.parse(input)) {
       case (Success(parsedResult), remainder) =>
         remainder shouldBe empty
-        parsedResult shouldBe (None, "albalb")
+        parsedResult shouldBe(None, "albalb")
 
         val resultXml = fooPickle.serialize(parsedResult, remainder)
         resultXml should equalTrimmed(input)
@@ -314,7 +314,7 @@ class XmlPickleTest extends FlatSpec with Matchers with Inside with XmlEquality 
     inside(fooPickle.parse(input)) {
       case (Success(parsedResult), remainder) =>
         remainder shouldBe empty
-        parsedResult shouldBe ("blabla", "albalb")
+        parsedResult shouldBe("blabla", "albalb")
 
         val resultXml = fooPickle.serialize(parsedResult, remainder)
         resultXml should equalTrimmed(input)
@@ -335,7 +335,7 @@ class XmlPickleTest extends FlatSpec with Matchers with Inside with XmlEquality 
     inside(fooPickle.parse(input)) {
       case (Success(parsedResult), remainder) =>
         remainder shouldBe empty
-        parsedResult shouldBe (None, None)
+        parsedResult shouldBe(None, None)
 
         val resultXml = fooPickle.serialize(parsedResult, remainder)
         resultXml should equalTrimmed(input)
@@ -405,7 +405,7 @@ class XmlPickleTest extends FlatSpec with Matchers with Inside with XmlEquality 
     inside(pickle.parse(input)) {
       case (Success(parsedResult), remainder) =>
         remainder should contain only <ghi>random2</ghi>
-        parsedResult shouldBe (Seq("test1", "test2", "test3", "test4"), Seq("random1", "random3"))
+        parsedResult shouldBe(Seq("test1", "test2", "test3", "test4"), Seq("random1", "random3"))
 
         val resultXml = pickle.serialize(parsedResult, remainder)
         resultXml should equalTrimmed(output)

--- a/core/src/test/scala/com/github/rvanheest/spickle/test/pickle/xml/XmlPickleTest.scala
+++ b/core/src/test/scala/com/github/rvanheest/spickle/test/pickle/xml/XmlPickleTest.scala
@@ -1,133 +1,239 @@
 package com.github.rvanheest.spickle.test.pickle.xml
 
 import com.github.rvanheest.spickle.pickle.xml.XmlPickle
-import com.github.rvanheest.spickle.pickle.xml.XmlPickle._
-import com.github.rvanheest.spickle.serializer.SerializerFailedException
+import com.github.rvanheest.spickle.pickle.xml.XmlPickle.{ stringNode, _ }
+import com.github.rvanheest.spickle.test.XmlEquality
 import org.scalatest.{ FlatSpec, Inside, Matchers }
 import shapeless.HNil
 
-import scala.util.{ Failure, Success }
+import scala.util.{ Success, Try }
 import scala.xml._
 
-class XmlPickleTest extends FlatSpec with Matchers with Inside {
+class XmlPickleTest extends FlatSpec with Matchers with Inside with XmlEquality {
+
+  private val xlinkNamespace: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
 
   private val foo = <foo>test</foo>
+  private val fooPf = <xlink:foo>test</xlink:foo>
   private val bar = <bar/>
-  private val baz = <baz>hello world</baz>
+  private val barPf = <xlink:bar/>
 
   "emptyNode" should "create an empty xml element with the given label" in {
-    emptyNode("bar").serialize((), Seq(foo, baz)) should matchPattern {
-      case Success(Seq(`bar`, `foo`, `baz`)) =>
+    val input = bar
+    val pickle = emptyNode("bar")
+    inside(pickle.parse(input)) {
+      case (Success(parsedResult), remainder) =>
+        remainder shouldBe empty
+
+        val resultXml = pickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(input)
+    }
+  }
+
+  "emptyNode with namespace" should "create an empty xml element with the given label and prefix" in {
+    val input = barPf
+    val pickle = emptyNode("bar", xlinkNamespace)
+    inside(pickle.parse(input)) {
+      case (Success(parsedResult), remainder) =>
+        remainder shouldBe empty
+
+        val resultXml = pickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(input)
     }
   }
 
   "node" should "pickle the input node if its label is equal to the given String" in {
-    node("foo").serialize(foo, Seq(bar, baz)) should matchPattern {
-      case Success(Seq(`foo`, `bar`, `baz`)) =>
+    val input = foo
+    val pickle = node("foo")
+    inside(pickle.parse(input)) {
+      case (result @ Success(parsedResult), remainder) =>
+        remainder shouldBe empty
+        result should equalTrimmed(input)
+
+        val resultXml = pickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(input)
     }
   }
 
-  it should "fail if the label of the input node does not match the given String" in {
-    val expectedMsg = s"element '$foo' does not contain an element with name 'bar'"
-    inside(node("bar").serialize(foo, Seq(bar, baz))) {
-      case Failure(e: NoSuchElementException) => e.getMessage shouldBe expectedMsg
+  "node with namespace" should "pickle the input node if its label and prefix are equal to the given String and namespace" in {
+    val input = fooPf
+    val pickle = node("foo", xlinkNamespace)
+    inside(pickle.parse(input)) {
+      case (result @ Success(parsedResult), remainder) =>
+        remainder shouldBe empty
+        result should equalTrimmed(input)
+
+        val resultXml = pickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(input)
     }
   }
 
   "stringNode" should "pickle the input text and wrap it in an xml element with the given label" in {
-    stringNode("foo").serialize(foo.text, Seq(bar, baz)) should matchPattern {
-      case Success(Seq(`foo`, `bar`, `baz`)) =>
+    val input = foo
+    val pickle = stringNode("foo")
+    inside(pickle.parse(input)) {
+      case (Success(parsedResult), remainder) =>
+        remainder shouldBe empty
+        parsedResult shouldBe "test"
+
+        val resultXml = pickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(input)
     }
   }
 
+  "stringNode with namespace" should "pickle the input text and wrap it in an xml element with the given label and prefix" in {
+    val input = fooPf
+    val pickle = stringNode("foo", xlinkNamespace)
+    inside(pickle.parse(input)) {
+      case (Success(parsedResult), remainder) =>
+        remainder shouldBe empty
+        parsedResult shouldBe "test"
+
+        val resultXml = pickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(input)
+    }
+  }
+
+  case class Foo(bars: Seq[Bar], baz: Baz)
+  case class Bar(s: String)
+  case class Baz(s: String)
+
   "branchNode" should "apply the subPickle to the contents of the input and wrap it all in a node with the given label" in {
-    val output =
-    // @formatter:off
+    val input = Utility.trim(
+      // @formatter:off
       <foo>
         <bar>hello</bar>
         <bar>world</bar>
         <baz>!</baz>
       </foo>
-      // @formatter:on
-      case class Foo(bars: Seq[Bar], baz: Baz)
-    case class Bar(s: String)
-    case class Baz(s: String)
+    // @formatter:on
+    )
+    val output = Foo(Seq(Bar("hello"), Bar("world")), Baz("!"))
 
-    val subPickle = for {
-      bars <- stringNode("bar").seq[Bar](_.s).map(Bar).many.seq[Foo](_.bars)
-      baz <- stringNode("baz").seq[Baz](_.s).map(Baz).seq[Foo](_.baz)
+    def barPickle: XmlPickle[Bar] = stringNode("bar").seq[Bar](_.s).map(Bar)
+
+    def bazPickle: XmlPickle[Baz] = stringNode("baz").seq[Baz](_.s).map(Baz)
+
+    def subPickle: XmlPickle[Foo] = for {
+      bars <- barPickle.many.seq[Foo](_.bars)
+      baz <- bazPickle.seq[Foo](_.baz)
     } yield Foo(bars, baz)
 
-    val foo = Foo(Seq(Bar("hello"), Bar("world")), Baz("!"))
+    val pickle = branchNode("foo")(subPickle)
 
-    inside(branchNode("foo")(subPickle).serialize(foo)) {
-      case Success(out) => out.toString() shouldBe Utility.trim(output).toString()
+    inside(pickle.parse(input)) {
+      case (Success(parsedResult), remainder) =>
+        remainder shouldBe empty
+        parsedResult shouldBe output
+
+        val resultXml = pickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(input)
     }
   }
 
-  "attribute" should "add an attribute to the node in the initial state with the given label and the data from the input" in {
-    // @formatter:off
-    val input = <foo hello="abc">bar</foo>
-    val output = <foo test="123" hello="abc">bar</foo>
+  "branchNode with namespace" should "apply the subPickle to the contents of the input and wrap it all in a node with the given label and prefix" in {
+    val dcNamespace = NamespaceBinding("dc", "http://purl.org/dc/elements/1.1/", TopScope)
+    val input = Utility.trim(
+      // @formatter:off
+      <xlink:foo>
+        <bar>hello</bar>
+        <bar>world</bar>
+        <dc:baz>!</dc:baz>
+      </xlink:foo>
     // @formatter:on
-    attribute("test").serialize("123", input) should matchPattern { case Success(Seq(`output`)) => }
-  }
+    )
+    val output = Foo(Seq(Bar("hello"), Bar("world")), Baz("!"))
 
-  it should "override existing attributes" in {
-    // @formatter:off
-    val input = <foo test="hello" hello="abc">bar</foo>
-    val output = <foo test="123" hello="abc">bar</foo>
-    // @formatter:on
-    attribute("test").serialize("123", input) should matchPattern {
-      case Success(Seq(`output`)) =>
+    def barPickle: XmlPickle[Bar] = stringNode("bar").seq[Bar](_.s).map(Bar)
+
+    def bazPickle: XmlPickle[Baz] = stringNode("baz", dcNamespace).seq[Baz](_.s).map(Baz)
+
+    def subPickle: XmlPickle[Foo] = for {
+      bars <- barPickle.many.seq[Foo](_.bars)
+      baz <- bazPickle.seq[Foo](_.baz)
+    } yield Foo(bars, baz)
+
+    val pickle = branchNode("foo", xlinkNamespace)(subPickle)
+
+    inside(pickle.parse(input)) {
+      case (Success(parsedResult), remainder) =>
+        remainder shouldBe empty
+        parsedResult shouldBe output
+
+        val resultXml = pickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(input)
     }
   }
 
-  it should "fail when the state is empty" in {
-    attribute("test").serialize("123") should matchPattern {
-      case Failure(SerializerFailedException("Cannot add an attribute with name 'test' to an empty node sequence")) =>
+  "attribute" should "pickle an attribute on a node with the given label" in {
+    val input = <foo test="123" hello="abc">bar</foo>
+    val pickle = attribute("test")
+
+    inside(pickle.parse(input)) {
+      case (Success(parsedResult), remainder) =>
+        Try { remainder } should equalTrimmed(input) // attributes are not taken out
+        parsedResult shouldBe "123"
+
+        val resultXml = pickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(input)
     }
   }
 
-  it should "fail if the first node in the state is not an element" in {
-    attribute("test").serialize("123", Comment("hello")) should matchPattern {
-      case Failure(SerializerFailedException("Can only add an attribute with name 'test' to elements: <!--hello-->")) =>
+  it should "pickle an attribute and branchNode" in {
+    val input = <foo baz="abc"><bar>test1</bar><bar>test2</bar></foo>
+    val output = Foo(Seq(Bar("test1"), Bar("test2")), Baz("abc"))
+    val pickle: XmlPickle[Foo] = for {
+      baz <- attribute("baz").seq[Baz](_.s).map(Baz).seq[Foo](_.baz)
+      foo <- branchNode("foo") {
+        for {
+          bars <- stringNode("bar").seq[Bar](_.s).map(Bar).many.seq[Foo](_.bars)
+        } yield Foo(bars, baz)
+      }.seqId
+    } yield foo
+
+    inside(pickle.parse(input)) {
+      case (Success(parsedResult), remainder) =>
+        remainder shouldBe empty
+        parsedResult shouldBe output
+
+        val resultXml = pickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(input)
     }
   }
 
-  "namespaceAttribute" should "add a namespace attribute to the node in the initial state with the given label and the data from the input" in {
-    // @formatter:off
-    val input = <foo hello="abc">bar</foo>
-    val output = <foo xlink:type="simple" hello="abc">bar</foo>
-    // @formatter:on
-    val ns: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
-    attribute("type", ns).serialize("simple", input) should matchPattern {
-      case Success(Seq(`output`)) =>
+  "attribute with namespace" should "pickle an attribute on a node with the given label" in {
+    val input = <foo xlink:test="123" hello="abc">bar</foo>
+    val pickle = attribute("test", xlinkNamespace)
+
+    inside(pickle.parse(input)) {
+      case (Success(parsedResult), remainder) =>
+        Try { remainder } should equalTrimmed(input) // attributes are not taken out
+        parsedResult shouldBe "123"
+
+        val resultXml = pickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(input)
     }
   }
 
-  it should "override existing attributes" in {
-    // @formatter:off
-    val input = <foo xlink:type="abc" hello="abc">bar</foo>
-    val output = <foo xlink:type="simple" hello="abc">bar</foo>
-    // @formatter:on
-    val ns: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
-    attribute("type", ns).serialize("simple", input) should matchPattern {
-      case Success(Seq(`output`)) =>
-    }
-  }
+  it should "pickle an attribute and branchNode" in {
+    val input = <foo xlink:baz="abc"><bar>test1</bar><bar>test2</bar></foo>
+    val output = Foo(Seq(Bar("test1"), Bar("test2")), Baz("abc"))
+    val pickle: XmlPickle[Foo] = for {
+      baz <- attribute("baz", xlinkNamespace).seq[Baz](_.s).map(Baz).seq[Foo](_.baz)
+      foo <- branchNode("foo") {
+        for {
+          bars <- stringNode("bar").seq[Bar](_.s).map(Bar).many.seq[Foo](_.bars)
+        } yield Foo(bars, baz)
+      }.seqId
+    } yield foo
 
-  it should "fail when the state is empty" in {
-    val ns: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
-    attribute("type", ns).serialize("simple") should matchPattern {
-      case Failure(SerializerFailedException("Cannot add an attribute with name 'xlink:type' to an empty node sequence")) =>
-    }
-  }
+    inside(pickle.parse(input)) {
+      case (Success(parsedResult), remainder) =>
+        remainder shouldBe empty
+        parsedResult shouldBe output
 
-  it should "fail if the first node in the state is not an element" in {
-    val ns: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
-    attribute("type", ns).serialize("simple", Comment("hello")) should matchPattern {
-      case Failure(SerializerFailedException("Can only add an attribute with name 'xlink:type' to elements: <!--hello-->")) =>
+        val resultXml = pickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(input)
     }
   }
 
@@ -141,9 +247,14 @@ class XmlPickleTest extends FlatSpec with Matchers with Inside {
       .map(_.reverse.tupled)
     val fooPickle = branchNode("foo")(combined)
 
-    val output = <foo><abc>blabla</abc><def>albalb</def></foo>
-    fooPickle.serialize((Some("blabla"), Some("albalb"))) should matchPattern {
-      case Success(Seq(`output`)) =>
+    val input = <foo><abc>blabla</abc><def>albalb</def></foo>
+    inside(fooPickle.parse(input)) {
+      case (Success(parsedResult), remainder) =>
+        remainder shouldBe empty
+        parsedResult shouldBe (Some("blabla"), Some("albalb"))
+
+        val resultXml = fooPickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(input)
     }
   }
 
@@ -157,9 +268,14 @@ class XmlPickleTest extends FlatSpec with Matchers with Inside {
       .map(_.reverse.tupled)
     val fooPickle = branchNode("foo")(combined)
 
-    val output = <foo><abc>blabla</abc><def>albalb</def></foo>
-    fooPickle.serialize((Some("blabla"), "albalb")) should matchPattern {
-      case Success(Seq(`output`)) =>
+    val input = <foo><abc>blabla</abc><def>albalb</def></foo>
+    inside(fooPickle.parse(input)) {
+      case (Success(parsedResult), remainder) =>
+        remainder shouldBe empty
+        parsedResult shouldBe (Some("blabla"), "albalb")
+
+        val resultXml = fooPickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(input)
     }
   }
 
@@ -173,9 +289,14 @@ class XmlPickleTest extends FlatSpec with Matchers with Inside {
       .map(_.reverse.tupled)
     val fooPickle = branchNode("foo")(combined)
 
-    val output = <foo><def>albalb</def></foo>
-    fooPickle.serialize((None, "albalb")) should matchPattern {
-      case Success(Seq(`output`)) =>
+    val input = <foo><def>albalb</def></foo>
+    inside(fooPickle.parse(input)) {
+      case (Success(parsedResult), remainder) =>
+        remainder shouldBe empty
+        parsedResult shouldBe (None, "albalb")
+
+        val resultXml = fooPickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(input)
     }
   }
 
@@ -189,9 +310,14 @@ class XmlPickleTest extends FlatSpec with Matchers with Inside {
       .map(_.reverse.tupled)
     val fooPickle = branchNode("foo")(combined)
 
-    val output = <foo><abc>blabla</abc><def>albalb</def></foo>
-    fooPickle.serialize(("blabla", "albalb")) should matchPattern {
-      case Success(Seq(`output`)) =>
+    val input = <foo><abc>blabla</abc><def>albalb</def></foo>
+    inside(fooPickle.parse(input)) {
+      case (Success(parsedResult), remainder) =>
+        remainder shouldBe empty
+        parsedResult shouldBe ("blabla", "albalb")
+
+        val resultXml = fooPickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(input)
     }
   }
 
@@ -205,9 +331,14 @@ class XmlPickleTest extends FlatSpec with Matchers with Inside {
       .map(_.reverse.tupled)
     val fooPickle = branchNode("foo")(combined)
 
-    val output = <foo></foo>
-    fooPickle.serialize((None, None)) should matchPattern {
-      case Success(Seq(`output`)) =>
+    val input = <foo></foo>
+    inside(fooPickle.parse(input)) {
+      case (Success(parsedResult), remainder) =>
+        remainder shouldBe empty
+        parsedResult shouldBe (None, None)
+
+        val resultXml = fooPickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(input)
     }
   }
 
@@ -221,15 +352,29 @@ class XmlPickleTest extends FlatSpec with Matchers with Inside {
       <abc>test3</abc>,
       <abc>test4</abc>
     )
-    val pickle = collect(stringNode("abc"))
-
-    val (result, remainder) = pickle.parse(input)
-    result should matchPattern { case Success(Seq("test1", "test2", "test3", "test4")) => }
-    remainder should contain only(
+    val output = Seq(
+      <abc>test1</abc>,
+      <abc>test2</abc>,
+      <abc>test3</abc>,
+      <abc>test4</abc>
       <def>random1</def>,
       <ghi>random2</ghi>,
       <klm>random3</klm>,
-    )
+    ).flatten
+    val pickle = collect(stringNode("abc"))
+
+    inside(pickle.parse(input)) {
+      case (Success(parsedResult), remainder) =>
+        remainder should contain only(
+          <def>random1</def>,
+          <ghi>random2</ghi>,
+          <klm>random3</klm>,
+        )
+        parsedResult shouldBe Seq("test1", "test2", "test3", "test4")
+
+        val resultXml = pickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(output)
+    }
   }
 
   it should "pass the remaining input to the next 'collect' parser" in {
@@ -242,15 +387,29 @@ class XmlPickleTest extends FlatSpec with Matchers with Inside {
       <abc>test3</abc>,
       <abc>test4</abc>
     )
+    val output = Seq(
+      <abc>test1</abc>,
+      <abc>test2</abc>,
+      <abc>test3</abc>,
+      <abc>test4</abc>
+      <def>random1</def>,
+      <def>random3</def>,
+      <ghi>random2</ghi>,
+    ).flatten
     type Output = (Seq[String], Seq[String])
     val pickle: XmlPickle[Output] = for {
       abcs <- collect(stringNode("abc")).seq[Output] { case (seq1, _) => seq1 }
       defs <- collect(stringNode("def")).seq[Output] { case (_, seq2) => seq2 }
     } yield (abcs, defs)
 
-    val (result, remainder) = pickle.parse(input)
-    result should matchPattern { case Success((Seq("test1", "test2", "test3", "test4"), Seq("random1", "random3"))) => }
-    remainder should contain only <ghi>random2</ghi>
+    inside(pickle.parse(input)) {
+      case (Success(parsedResult), remainder) =>
+        remainder should contain only <ghi>random2</ghi>
+        parsedResult shouldBe (Seq("test1", "test2", "test3", "test4"), Seq("random1", "random3"))
+
+        val resultXml = pickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(output)
+    }
   }
 
   it should "don't collect any nodes if they all don't satisfy the parser" in {
@@ -265,87 +424,13 @@ class XmlPickleTest extends FlatSpec with Matchers with Inside {
     )
     val pickle = collect(stringNode("unknown-node"))
 
-    val (result, remainder) = pickle.parse(input)
-    result should matchPattern { case Success(Seq()) => }
-    remainder shouldBe input
-  }
+    inside(pickle.parse(input)) {
+      case (Success(parsedResult), remainder) =>
+        remainder should contain theSameElementsInOrderAs input
+        parsedResult shouldBe empty
 
-  it should "convert all input one-by-one and in order according to the given serializer" in {
-    val input = Seq("test1", "test2", "test3", "test4")
-    val pickle = collect(stringNode("abc"))
-
-    inside(pickle.serialize(input)) {
-      case Success(xml) =>
-        xml should contain inOrderOnly(
-          <abc>test1</abc>,
-          <abc>test2</abc>,
-          <abc>test3</abc>,
-          <abc>test4</abc>,
-        )
-    }
-  }
-
-  it should "compose with other collect operators" in {
-    val input = (Seq("test1", "test2", "test3", "test4"), Seq("random1", "random3"))
-
-    type Output = (Seq[String], Seq[String])
-    val pickle: XmlPickle[Output] = for {
-      abcs <- collect(stringNode("abc")).seq[Output] { case (seq1, _) => seq1 }
-      defs <- collect(stringNode("def")).seq[Output] { case (_, seq2) => seq2 }
-    } yield (abcs, defs)
-
-    inside(pickle.serialize(input)) {
-      case Success(xml) =>
-        xml should contain inOrderOnly(
-          <abc>test1</abc>,
-          <abc>test2</abc>,
-          <abc>test3</abc>,
-          <abc>test4</abc>,
-          <def>random1</def>,
-          <def>random3</def>,
-        )
-    }
-  }
-
-  it should "convert an empty list into an empty sequence of nodes" in {
-    val input = Seq.empty[String]
-    val pickle = collect(stringNode("abc"))
-
-    pickle.serialize(input) should matchPattern { case Success(Seq()) => }
-  }
-
-  it should "have sorted a xs-choice-many content after first parsing it, and then serializing it again" in {
-    val input = Seq(
-      <abc>test1</abc>,
-      <def>random1</def>,
-      <abc>test2</abc>,
-      <ghi>random2</ghi>,
-      <def>random3</def>,
-      <abc>test3</abc>,
-      <abc>test4</abc>
-    )
-
-    type Output = (Seq[String], Seq[String])
-    val pickle: XmlPickle[Output] = for {
-      abcs <- collect(stringNode("abc")).seq[Output] { case (seq1, _) => seq1 }
-      defs <- collect(stringNode("def")).seq[Output] { case (_, seq2) => seq2 }
-    } yield (abcs, defs)
-
-    val (result, remainder) = pickle.parse(input)
-    inside(result) {
-      case Success(output) =>
-        inside(pickle.serialize(output, remainder)) {
-          case Success(outputXml) =>
-            outputXml should contain inOrderOnly(
-              <abc>test1</abc>,
-              <abc>test2</abc>,
-              <abc>test3</abc>,
-              <abc>test4</abc>,
-              <def>random1</def>,
-              <def>random3</def>,
-              <ghi>random2</ghi>,
-            )
-        }
+        val resultXml = pickle.serialize(parsedResult, remainder)
+        resultXml should equalTrimmed(input)
     }
   }
 }

--- a/core/src/test/scala/com/github/rvanheest/spickle/test/serializer/xml/XmlSerializerTest.scala
+++ b/core/src/test/scala/com/github/rvanheest/spickle/test/serializer/xml/XmlSerializerTest.scala
@@ -201,6 +201,34 @@ class XmlSerializerTest extends FlatSpec with Matchers with Inside with XmlEqual
     }
   }
 
+  "withNamespace" should "add a namespace to the node serialized with the given serializer" in {
+    val expectedResult = <foo xmlns:xlink="http://www.w3.org/1999/xlink"><xlink:bar>test1</xlink:bar><xlink:bar>test2</xlink:bar></foo>
+
+    val barSerializer = stringNode("bar", xlinkNamespace)
+    val fooSerializer = branchNode("foo")(barSerializer.many)
+    val serializer = withNamespace(xlinkNamespace)(fooSerializer)
+
+    serializer.serialize(Seq("test1", "test2")) should equalTrimmed(expectedResult)
+  }
+
+  it should "add a namespace to a subnode in the tree" in {
+    val expectedResult = <foo><xlink:bar xmlns:xlink="http://www.w3.org/1999/xlink">test1</xlink:bar><xlink:bar xmlns:xlink="http://www.w3.org/1999/xlink">test2</xlink:bar></foo>
+
+    val barSerializer = withNamespace(xlinkNamespace)(stringNode("bar", xlinkNamespace))
+    val serializer = branchNode("foo")(barSerializer.many)
+
+    serializer.serialize(Seq("test1", "test2")) should equalTrimmed(expectedResult)
+  }
+
+  it should "add a namespace to every node in the sequence produced by the given serializer" in {
+    val expectedResult = <foo><xlink:bar xmlns:xlink="http://www.w3.org/1999/xlink">test1</xlink:bar><xlink:bar xmlns:xlink="http://www.w3.org/1999/xlink">test2</xlink:bar></foo>
+
+    val barSerializer = stringNode("bar", xlinkNamespace)
+    val serializer = branchNode("foo")(withNamespace(xlinkNamespace)(barSerializer.many))
+
+    serializer.serialize(Seq("test1", "test2")) should equalTrimmed(expectedResult)
+  }
+
   "collect" should "convert all input one-by-one and in order according to the given serializer" in {
     val input = Seq("test1", "test2", "test3", "test4")
     val serializer = collect(stringNode("abc"))

--- a/core/src/test/scala/com/github/rvanheest/spickle/test/serializer/xml/XmlSerializerTest.scala
+++ b/core/src/test/scala/com/github/rvanheest/spickle/test/serializer/xml/XmlSerializerTest.scala
@@ -1,11 +1,205 @@
 package com.github.rvanheest.spickle.test.serializer.xml
 
+import com.github.rvanheest.spickle.serializer.SerializerFailedException
 import com.github.rvanheest.spickle.serializer.xml.XmlSerializer._
+import com.github.rvanheest.spickle.test.XmlEquality
 import org.scalatest.{ FlatSpec, Inside, Matchers }
 
-import scala.util.Success
+import scala.util.{ Failure, Success }
+import scala.xml.{ Comment, NamespaceBinding, TopScope }
 
-class XmlSerializerTest extends FlatSpec with Matchers with Inside {
+class XmlSerializerTest extends FlatSpec with Matchers with Inside with XmlEquality {
+
+  private val xlinkNamespace: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
+
+  "emptyNode" should "generate an empty node with the given name" in {
+    val expectedResult = <foo/>
+    emptyNode("foo").serialize(()) should equalTrimmed(expectedResult)
+  }
+
+  "emptyNode with namespace" should "generate an empty node with the given name and namespace" in {
+    val expectedResult = <xlink:foo/>
+    emptyNode("foo", xlinkNamespace).serialize(()) should equalTrimmed(expectedResult)
+  }
+
+  "node" should "append the input xml to the output if it matches the given label name" in {
+    val expectedResult = Seq(<foo>test1</foo>, <bar>test2</bar>)
+    node("foo").serialize(<foo>test1</foo>, Seq(<bar>test2</bar>)) should equalTrimmed(expectedResult)
+  }
+
+  it should "fail when the input xml has a different label than the given name" in {
+    val input = <foo>test1</foo>
+    inside(node("not-foo").serialize(input, Seq(<bar>test2</bar>))) {
+      case Failure(e: NoSuchElementException) =>
+        e should have message s"element '$input' does not contain an element with name 'not-foo'"
+    }
+  }
+
+  "node with namespace" should "append the input xml to the output if it matches the given label name" in {
+    val input1 = <xlink:foo xmlns:xlink="http://www.w3.org/1999/xlink">test1</xlink:foo>
+    val input2 = <bar>test2</bar>
+
+    node("foo", xlinkNamespace).serialize(input1, Seq(input2)) should equalTrimmed(Seq(input1, input2))
+  }
+
+  it should "fail when the input xml has a different label than the given name" in {
+    val input = <xlink:foo xmlns:xlink="http://www.w3.org/1999/xlink">test1</xlink:foo>
+    inside(node("not-foo", xlinkNamespace).serialize(input, Seq(<bar>test2</bar>))) {
+      case Failure(e: NoSuchElementException) =>
+        val namespace = "xmlns:xlink=\"http://www.w3.org/1999/xlink\""
+        e should have message s"element '$input' does not contain an element with name 'not-foo' and namespace '$namespace'"
+    }
+  }
+
+  it should "fail when the input xml has a different namespace than the given one" in {
+    val input = <foo>test1</foo>.copy(prefix = "dc")
+    inside(node("foo", xlinkNamespace).serialize(input, Seq(<bar>test2</bar>))) {
+      case Failure(e: NoSuchElementException) =>
+        val namespace = "xmlns:xlink=\"http://www.w3.org/1999/xlink\""
+        e should have message s"element '$input' does not contain an element with name 'foo' and namespace '$namespace'"
+    }
+  }
+
+  it should "fail when the input xml has no namespace, while some namespace was provided" in {
+    val input = <foo>test1</foo>
+    inside(node("foo", xlinkNamespace).serialize(input, Seq(<bar>test2</bar>))) {
+      case Failure(e: NoSuchElementException) =>
+        val namespace = "xmlns:xlink=\"http://www.w3.org/1999/xlink\""
+        e should have message s"element '$input' does not contain an element with name 'foo' and namespace '$namespace'"
+    }
+  }
+
+  "stringNode" should "create an xml node with the given content" in {
+    val expectedResult = <foo>test1</foo>
+    stringNode("foo").serialize("test1") should equalTrimmed(expectedResult)
+  }
+
+  it should "create an empty node when the input is an empty string" in {
+    val expectedResult = <foo></foo>
+    stringNode("foo").serialize("") should equalTrimmed(expectedResult)
+  }
+
+  "stringNode with namespace" should "create an xml node with the given content and namespace" in {
+    val expectedResult = <xlink:foo>test1</xlink:foo>
+    stringNode("foo", xlinkNamespace).serialize("test1") should equalTrimmed(expectedResult)
+  }
+
+  it should "create an empty node when the input is an empty string" in {
+    val expectedResult = <xlink:foo></xlink:foo>
+    stringNode("foo", xlinkNamespace).serialize("") should equalTrimmed(expectedResult)
+  }
+
+  "branchNode" should "create an xml tree with an outer node 'foo' and an inner node 'bar'" in {
+    val expectedResult = <foo><bar>test1</bar></foo>
+    branchNode("foo")(stringNode("bar")).serialize("test1") should equalTrimmed(expectedResult)
+  }
+
+  it should "create an xml tree with an outer node 'foo' and an inner node 'bar' with namespace" in {
+    val expectedResult = <foo><xlink:bar>test1</xlink:bar></foo>
+    branchNode("foo")(stringNode("bar", xlinkNamespace)).serialize("test1") should equalTrimmed(expectedResult)
+  }
+
+  "branchNode with namespace" should "create an xml tree with an outer node 'foo' with namespace and an inner node 'bar'" in {
+    val expectedResult = <xlink:foo><bar>test1</bar></xlink:foo>
+    branchNode("foo", xlinkNamespace)(stringNode("bar")).serialize("test1") should equalTrimmed(expectedResult)
+  }
+
+  it should "create an xml tree with an outer node 'foo' with namespace and an inner node 'bar' with namespace" in {
+    val expectedResult = <xlink:foo><xlink:bar>test1</xlink:bar></xlink:foo>
+    branchNode("foo", xlinkNamespace)(stringNode("bar", xlinkNamespace)).serialize("test1") should equalTrimmed(expectedResult)
+  }
+
+  it should "create an xml tree with an outer node 'foo' with namespace and an inner node 'bar' with namespace and an inner-inner node 'baz' with namespace" in {
+    val expectedResult = <xlink:foo><xlink:bar><xlink:baz>test1</xlink:baz></xlink:bar></xlink:foo>
+    branchNode("foo", xlinkNamespace)(branchNode("bar", xlinkNamespace)(stringNode("baz", xlinkNamespace))).serialize("test1") should equalTrimmed(expectedResult)
+  }
+
+  "attribute" should "add an attribute to the node in the initial state with the given label and the data from the input" in {
+    val input = <foo hello="abc">bar</foo>
+    val output = <foo test="123" hello="abc">bar</foo>
+
+    attribute("test").serialize("123", input) should equalTrimmed(output)
+  }
+
+  it should "append an attribute to a node" in {
+    val expectedResult = <foo bar="test1">test2</foo>
+
+    attribute("bar").contramap[(String, String)] { case (left, _) => left }
+      .combine(stringNode("foo").contramap { case (_, right) => right })
+      .serialize(("test1", "test2")) should equalTrimmed(expectedResult)
+  }
+
+  it should "append multiple attributes to a node" in {
+    val expectedResult = <foo bar="test1" baz="test2">test3</foo>
+
+    attribute("bar").contramap[(String, String, String)] { case (left, _, _) => left }
+      .combine(attribute("baz").contramap { case (_, middle, _) => middle })
+      .combine(stringNode("foo").contramap { case (_, _, right) => right })
+      .serialize(("test1", "test2", "test3")) should equalTrimmed(expectedResult)
+  }
+
+  it should "override existing attributes" in {
+    val input = <foo test="hello" hello="abc">bar</foo>
+    val output = <foo test="123" hello="abc">bar</foo>
+    attribute("test").serialize("123", input) should equalTrimmed(output)
+  }
+
+  it should "fail when there is only a comment to append the attribute to" in {
+    attribute("bar").serialize("test1", Comment("hello world")) should matchPattern {
+      case Failure(SerializerFailedException("Can only add an attribute with name 'bar' to elements: <!--hello world-->")) =>
+    }
+  }
+
+  it should "fail when there is no node to append the attribute to" in {
+    attribute("bar").serialize("test1") should matchPattern {
+      case Failure(SerializerFailedException("Cannot add an attribute with name 'bar' to an empty node sequence")) =>
+    }
+  }
+
+  "attribute with namespace" should "add an attribute to the node in the initial state with the given label and the data from the input" in {
+    // @formatter:off
+    val input = <foo hello="abc">bar</foo>
+    val output = <foo xlink:test="123" hello="abc">bar</foo>
+    // @formatter:on
+
+    attribute("test", xlinkNamespace).serialize("123", input) should equalTrimmed(output)
+  }
+
+  it should "append an attribute to a node" in {
+    val expectedResult = <foo xlink:bar="test1">test2</foo>
+    attribute("bar", xlinkNamespace).contramap[(String, String)] { case (left, _) => left }
+      .combine(stringNode("foo").contramap { case (_, right) => right })
+      .serialize(("test1", "test2")) should equalTrimmed(expectedResult)
+  }
+
+  it should "append multiple attributes to a node" in {
+    val expectedResult = <foo xlink:bar="test1" xlink:baz="test2">test3</foo>
+
+    attribute("bar", xlinkNamespace).contramap[(String, String, String)] { case (left, _, _) => left }
+      .combine(attribute("baz", xlinkNamespace).contramap { case (_, middle, _) => middle })
+      .combine(stringNode("foo").contramap { case (_, _, right) => right })
+      .serialize(("test1", "test2", "test3")) should equalTrimmed(expectedResult)
+  }
+
+  it should "override existing attributes" in {
+    // @formatter:off
+    val input = <foo xlink:test="hello" hello="abc">bar</foo>
+    val output = <foo xlink:test="123" hello="abc">bar</foo>
+    // @formatter:on
+    attribute("test", xlinkNamespace).serialize("123", input) should equalTrimmed(output)
+  }
+
+  it should "fail when there is only a comment to append the attribute to" in {
+    attribute("bar", xlinkNamespace).serialize("test1", Comment("hello world")) should matchPattern {
+      case Failure(SerializerFailedException("Can only add an attribute with name 'xlink:bar' to elements: <!--hello world-->")) =>
+    }
+  }
+
+  it should "fail when there is no node to append the attribute to" in {
+    attribute("bar", xlinkNamespace).serialize("test1") should matchPattern {
+      case Failure(SerializerFailedException("Cannot add an attribute with name 'xlink:bar' to an empty node sequence")) =>
+    }
+  }
 
   "collect" should "convert all input one-by-one and in order according to the given serializer" in {
     val input = Seq("test1", "test2", "test3", "test4")
@@ -13,7 +207,7 @@ class XmlSerializerTest extends FlatSpec with Matchers with Inside {
 
     inside(serializer.serialize(input)) {
       case Success(xml) =>
-        xml should contain inOrderOnly (
+        xml should contain inOrderOnly(
           <abc>test1</abc>,
           <abc>test2</abc>,
           <abc>test3</abc>,
@@ -28,11 +222,11 @@ class XmlSerializerTest extends FlatSpec with Matchers with Inside {
     val abcSerializer = collect(stringNode("abc"))
     val defSerializer = collect(stringNode("def"))
     val serializer = abcSerializer.contramap[(Seq[String], Seq[String])] { case (seq1, _) => seq1 }
-      .combine(defSerializer.contramap { case (_, seq2) => seq2 } )
+      .combine(defSerializer.contramap { case (_, seq2) => seq2 })
 
     inside(serializer.serialize(input)) {
       case Success(xml) =>
-        xml should contain inOrderOnly (
+        xml should contain inOrderOnly(
           <abc>test1</abc>,
           <abc>test2</abc>,
           <abc>test3</abc>,

--- a/example/src/main/resources/namespace/note1.xml
+++ b/example/src/main/resources/namespace/note1.xml
@@ -1,0 +1,18 @@
+<note xmlns="http://www.github.com/rvanheest/spickle/example/namespace"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      xmlns:dcterms="http://purl.org/dc/terms/"
+      xsi:noNamespaceSchemaLocation="schema.xsd">
+
+    <dc:title>dc-title1</dc:title>
+
+    <dcterms:title>dcterms-title1</dcterms:title>
+
+    <dcterms:description>dcterms-description1</dcterms:description>
+
+    <dc:title>dc-title2</dc:title>
+    <dc:title>dc-title3</dc:title>
+
+    <dcterms:description>dcterms-description2</dcterms:description>
+    <dcterms:description>dcterms-description3</dcterms:description>
+</note>

--- a/example/src/main/resources/namespace/note2.xml
+++ b/example/src/main/resources/namespace/note2.xml
@@ -1,0 +1,18 @@
+<ns:note xmlns:ns="http://www.github.com/rvanheest/spickle/example/namespace"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:dcterms="http://purl.org/dc/terms/"
+         xsi:schemaLocation="http://www.github.com/rvanheest/spickle/example/namespace https://raw.githubusercontent.com/rvanheest/spickle/16bfbc384aaea114a32a4c60d0fdd5cbd2845c98/example/src/main/resources/namespace/schema.xsd">
+
+    <dc:title>dc-title1</dc:title>
+
+    <dcterms:title>dcterms-title1</dcterms:title>
+
+    <dcterms:description>dcterms-description1</dcterms:description>
+
+    <dc:title>dc-title2</dc:title>
+    <dc:title>dc-title3</dc:title>
+
+    <dcterms:description>dcterms-description2</dcterms:description>
+    <dcterms:description>dcterms-description3</dcterms:description>
+</ns:note>

--- a/example/src/main/resources/namespace/schema.xsd
+++ b/example/src/main/resources/namespace/schema.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:dcterms="http://purl.org/dc/terms/"
+           xmlns:dc="http://purl.org/dc/elements/1.1/"
+           targetNamespace="http://www.github.com/rvanheest/spickle/example/namespace"
+           elementFormDefault="qualified">
+
+    <!-- =================================================================================== -->
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
+    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="http://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
+    <!-- =================================================================================== -->
+
+    <xs:element name="note">
+        <xs:complexType>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="dc:title"/>
+                <xs:element ref="dcterms:title"/>
+                <xs:element ref="dcterms:description"/>
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/example/src/main/scala/com/github/rvanheest/spickle/example/xml/README.md
+++ b/example/src/main/scala/com/github/rvanheest/spickle/example/xml/README.md
@@ -1,9 +1,11 @@
 This package contains a number of examples on how to use the `XmlParser`, `XmlSerializer` and `XmlPickle`.
 
 * **[person/](./person)** contains a good first example on how to use the parsers, serializers and
-  pickles for reading an XML structure into an object model and writing the object back as _the same_ XML
+  pickles for reading an XML structure into an object model and writing the object back as _the same_ XML.
 * **[baseball/](./baseball)** shows how to deal with XML structures that contain lots of attributes.
 * **[all/](./all)** demonstrates how to handle an [`<xs:all/>`](https://www.w3schools.com/xml/el_all.asp)
   element using the `fromAll` builder methods. See also the related XML files in the [resources](../../../../../../../resources/all).
 * **[xsChoiceMany](./xsChoiceMany)** demonstrates how to handle an [`<xs:choice minOccurs="0" maxOccurs="unbounded"/>`](https://www.w3schools.com/xml/el_choice.asp)
   element using the `collect` operator. See also the related XML and XSD files in the [resources](../../../../../../../resources/xs-choice-many).
+* **[namespace](./namespace)** shows how to add [namespaces](https://www.w3schools.com/xml/xml_namespaces.asp)
+  and namespace prefixes to nodes, and how to include schema references in the XML structure.

--- a/example/src/main/scala/com/github/rvanheest/spickle/example/xml/README.md
+++ b/example/src/main/scala/com/github/rvanheest/spickle/example/xml/README.md
@@ -8,4 +8,5 @@ This package contains a number of examples on how to use the `XmlParser`, `XmlSe
 * **[xsChoiceMany](./xsChoiceMany)** demonstrates how to handle an [`<xs:choice minOccurs="0" maxOccurs="unbounded"/>`](https://www.w3schools.com/xml/el_choice.asp)
   element using the `collect` operator. See also the related XML and XSD files in the [resources](../../../../../../../resources/xs-choice-many).
 * **[namespace](./namespace)** shows how to add [namespaces](https://www.w3schools.com/xml/xml_namespaces.asp)
-  and namespace prefixes to nodes, and how to include schema references in the XML structure.
+  and namespace prefixes to nodes, and how to include schema references in the XML structure. See
+  also the related XML and XSD files in the [resources](../../../../../../../resources/namespace).

--- a/example/src/main/scala/com/github/rvanheest/spickle/example/xml/namespace/Namespace.scala
+++ b/example/src/main/scala/com/github/rvanheest/spickle/example/xml/namespace/Namespace.scala
@@ -1,0 +1,8 @@
+package com.github.rvanheest.spickle.example.xml.namespace
+
+object Namespace {
+
+  case class Note(dcTitle: Seq[String],
+                  dctermsTitle: Seq[String],
+                  dctermsDescription: Seq[String])
+}

--- a/example/src/main/scala/com/github/rvanheest/spickle/example/xml/namespace/NamespaceParser.scala
+++ b/example/src/main/scala/com/github/rvanheest/spickle/example/xml/namespace/NamespaceParser.scala
@@ -1,0 +1,49 @@
+package com.github.rvanheest.spickle.example.xml.namespace
+
+import java.nio.file.Paths
+
+import com.github.rvanheest.spickle.example.xml.namespace.Namespace.Note
+import com.github.rvanheest.spickle.parser.xml.XmlParser.{ XmlParser, _ }
+
+import scala.util.Success
+import scala.xml.{ NamespaceBinding, TopScope, Utility, XML }
+
+object NamespaceParserRunner extends App {
+
+  val path = Paths.get(getClass.getResource("/namespace/note1.xml").toURI)
+  val xml = Utility.trim(XML.loadFile(path.toFile))
+
+  println(xml)
+
+  val (Success(note), remainder) = NamespaceParser.parseNote.parse(xml)
+  println(s"result: $note")
+  println(s"remainder: ${ if (remainder.isEmpty) "<empty>" else remainder }")
+}
+
+object NamespaceParser {
+
+  val dc: NamespaceBinding = NamespaceBinding("dc", "http://purl.org/dc/elements/1.1/", TopScope)
+  val dcterms: NamespaceBinding = NamespaceBinding("dcterms", "http://purl.org/dc/terms/", TopScope)
+
+  def parseNote: XmlParser[Note] = {
+    branchNode("note") {
+      for {
+        dcTitles <- parseDcTitles
+        dctermsTitles <- parseDctermsTitles
+        dctermsDescriptions <- parseDctermsDescriptions
+      } yield Note(dcTitles, dctermsTitles, dctermsDescriptions)
+    }
+  }
+
+  def parseDcTitles: XmlParser[Seq[String]] = {
+    collect(stringNode("title", dc))
+  }
+
+  def parseDctermsTitles: XmlParser[Seq[String]] = {
+    collect(stringNode("title", dcterms))
+  }
+
+  def parseDctermsDescriptions: XmlParser[Seq[String]] = {
+    collect(stringNode("description", dcterms))
+  }
+}

--- a/example/src/main/scala/com/github/rvanheest/spickle/example/xml/namespace/NamespacePickle1.scala
+++ b/example/src/main/scala/com/github/rvanheest/spickle/example/xml/namespace/NamespacePickle1.scala
@@ -1,0 +1,66 @@
+package com.github.rvanheest.spickle.example.xml.namespace
+
+import java.nio.file.Paths
+
+import com.github.rvanheest.spickle.example.xml.namespace.Namespace.Note
+import com.github.rvanheest.spickle.pickle.xml.XmlPickle._
+
+import scala.util.Success
+import scala.xml._
+
+object NamespacePickle1Runner extends App {
+
+  val pickle = NamespacePickle1.pickleNamespacedNote
+
+  val path = Paths.get(getClass.getResource("/namespace/note1.xml").toURI)
+  val xml = Utility.trim(XML.loadFile(path.toFile))
+
+  println(new PrettyPrinter(160, 2).format(xml))
+
+  val (Success(note), remainder) = pickle.parse(xml)
+  println(s"result: $note")
+  println(s"remainder: ${ if (remainder.isEmpty) "<empty>" else remainder }")
+
+  val Success(Seq(resultXml)) = pickle.serialize(note)
+  println(new PrettyPrinter(160, 2).format(resultXml))
+}
+
+object NamespacePickle1 {
+
+  val dc: NamespaceBinding = NamespaceBinding("dc", "http://purl.org/dc/elements/1.1/", TopScope)
+  val dcterms: NamespaceBinding = NamespaceBinding("dcterms", "http://purl.org/dc/terms/", TopScope)
+  val xsi: NamespaceBinding = NamespaceBinding("xsi", "http://www.w3.org/2001/XMLSchema-instance", TopScope)
+
+  val namespace: NamespaceBinding = NamespaceBinding("xsi", "http://www.w3.org/2001/XMLSchema-instance", NamespaceBinding("dc", "http://purl.org/dc/elements/1.1/", NamespaceBinding("dcterms", "http://purl.org/dc/terms/", TopScope)))
+
+  def pickleNamespacedNote: XmlPickle[Note] = {
+    withNamespace(namespace) {
+      for {
+        _ <- attribute("noNamespaceSchemaLocation", xsi).seq[Note](_ => "scheme.xsd")
+        note <- pickleNote.seqId
+      } yield note
+    }
+  }
+
+  def pickleNote: XmlPickle[Note] = {
+    branchNode("note") {
+      for {
+        dcTitles <- pickleDcTitles.seq[Note](_.dcTitle)
+        dctermsTitles <- pickleDctermsTitles.seq[Note](_.dctermsTitle)
+        dctermsDescription <- pickleDctermsDescription.seq[Note](_.dctermsDescription)
+      } yield Note(dcTitles, dctermsTitles, dctermsDescription)
+    }
+  }
+
+  def pickleDcTitles: XmlPickle[Seq[String]] = {
+    collect(stringNode("title", dc))
+  }
+
+  def pickleDctermsTitles: XmlPickle[Seq[String]] = {
+    collect(stringNode("title", dcterms))
+  }
+
+  def pickleDctermsDescription: XmlPickle[Seq[String]] = {
+    collect(stringNode("description", dcterms))
+  }
+}

--- a/example/src/main/scala/com/github/rvanheest/spickle/example/xml/namespace/NamespacePickle2.scala
+++ b/example/src/main/scala/com/github/rvanheest/spickle/example/xml/namespace/NamespacePickle2.scala
@@ -1,0 +1,67 @@
+package com.github.rvanheest.spickle.example.xml.namespace
+
+import java.nio.file.Paths
+
+import com.github.rvanheest.spickle.example.xml.namespace.Namespace.Note
+import com.github.rvanheest.spickle.pickle.xml.XmlPickle._
+
+import scala.util.Success
+import scala.xml._
+
+object NamespacePickle2Runner extends App {
+
+  val pickle = NamespacePickle2.pickleNamespacedNote
+
+  val path = Paths.get(getClass.getResource("/namespace/note2.xml").toURI)
+  val xml = Utility.trim(XML.loadFile(path.toFile))
+
+  println(new PrettyPrinter(160, 2).format(xml))
+
+  val (Success(note), remainder) = pickle.parse(xml)
+  println(s"result: $note")
+  println(s"remainder: ${ if (remainder.isEmpty) "<empty>" else remainder }")
+
+  val Success(Seq(resultXml)) = pickle.serialize(note)
+  println(new PrettyPrinter(160, 2).format(resultXml))
+}
+
+object NamespacePickle2 {
+
+  val ns: NamespaceBinding = NamespaceBinding("ns", "http://www.github.com/rvanheest/spickle/example/namespace", TopScope)
+  val dc: NamespaceBinding = NamespaceBinding("dc", "http://purl.org/dc/elements/1.1/", TopScope)
+  val dcterms: NamespaceBinding = NamespaceBinding("dcterms", "http://purl.org/dc/terms/", TopScope)
+  val xsi: NamespaceBinding = NamespaceBinding("xsi", "http://www.w3.org/2001/XMLSchema-instance", TopScope)
+
+  val namespace: NamespaceBinding = NamespaceBinding("ns", "http://www.github.com/rvanheest/spickle/example/namespace", NamespaceBinding("xsi", "http://www.w3.org/2001/XMLSchema-instance", NamespaceBinding("dc", "http://purl.org/dc/elements/1.1/", NamespaceBinding("dcterms", "http://purl.org/dc/terms/", TopScope))))
+
+  def pickleNamespacedNote: XmlPickle[Note] = {
+    withNamespace(namespace) {
+      for {
+        _ <- attribute("schemaLocation", xsi).seq[Note](_ => "http://www.github.com/rvanheest/spickle/example/namespace https://raw.githubusercontent.com/rvanheest/spickle/16bfbc384aaea114a32a4c60d0fdd5cbd2845c98/example/src/main/resources/namespace/schema.xsd")
+        note <- pickleNote.seqId
+      } yield note
+    }
+  }
+
+  def pickleNote: XmlPickle[Note] = {
+    branchNode("note") {
+      for {
+        dcTitles <- pickleDcTitles.seq[Note](_.dcTitle)
+        dctermsTitles <- pickleDctermsTitles.seq[Note](_.dctermsTitle)
+        dctermsDescription <- pickleDctermsDescription.seq[Note](_.dctermsDescription)
+      } yield Note(dcTitles, dctermsTitles, dctermsDescription)
+    }
+  }
+
+  def pickleDcTitles: XmlPickle[Seq[String]] = {
+    collect(stringNode("title", dc))
+  }
+
+  def pickleDctermsTitles: XmlPickle[Seq[String]] = {
+    collect(stringNode("title", dcterms))
+  }
+
+  def pickleDctermsDescription: XmlPickle[Seq[String]] = {
+    collect(stringNode("description", dcterms))
+  }
+}

--- a/example/src/main/scala/com/github/rvanheest/spickle/example/xml/namespace/NamespaceSerializer1.scala
+++ b/example/src/main/scala/com/github/rvanheest/spickle/example/xml/namespace/NamespaceSerializer1.scala
@@ -1,0 +1,57 @@
+package com.github.rvanheest.spickle.example.xml.namespace
+
+import com.github.rvanheest.spickle.example.xml.namespace.Namespace.Note
+import com.github.rvanheest.spickle.serializer.xml.XmlSerializer._
+
+import scala.util.Success
+import scala.xml._
+
+object NamespaceSerializer1Runner extends App {
+
+  val input = Note(
+    Seq("dc-title1", "dc-title2", "dc-title3"),
+    Seq("dcterms-title1"),
+    Seq("dcterms-description1", "dcterms-description2", "dcterms-description3")
+  )
+  println(input)
+
+  val Success(Seq(xml1)) = NamespaceSerializer1.serializeNamespacedNote.serialize(input)
+  println(new PrettyPrinter(160, 2).format(xml1))
+}
+
+object NamespaceSerializer1 {
+
+  val default: NamespaceBinding = NamespaceBinding(null, "http://www.github.com/rvanheest/spickle/example/namespace", TopScope)
+  val dc: NamespaceBinding = NamespaceBinding("dc", "http://purl.org/dc/elements/1.1/", TopScope)
+  val dcterms: NamespaceBinding = NamespaceBinding("dcterms", "http://purl.org/dc/terms/", TopScope)
+  val xsi: NamespaceBinding = NamespaceBinding("xsi", "http://www.w3.org/2001/XMLSchema-instance", TopScope)
+
+  val namespace: NamespaceBinding = NamespaceBinding(null, "http://www.github.com/rvanheest/spickle/example/namespace", NamespaceBinding("xsi", "http://www.w3.org/2001/XMLSchema-instance", NamespaceBinding("dc", "http://purl.org/dc/elements/1.1/", NamespaceBinding("dcterms", "http://purl.org/dc/terms/", TopScope))))
+
+  def serializeNamespacedNote: XmlSerializer[Note] = {
+    withNamespace(namespace) {
+      attribute("noNamespaceSchemaLocation", xsi).contramap[Note](_ => "schema.xsd")
+        .combine(serializeNote)
+    }
+  }
+
+  def serializeNote: XmlSerializer[Note] = {
+    branchNode("note", default) {
+      serializeDcTitles.contramap[Note](_.dcTitle)
+        .combine(serializeDctermsTitles.contramap(_.dctermsTitle))
+        .combine(serializeDctermsDescription.contramap(_.dctermsDescription))
+    }
+  }
+
+  def serializeDcTitles: XmlSerializer[Seq[String]] = {
+    collect(stringNode("title", dc))
+  }
+
+  def serializeDctermsTitles: XmlSerializer[Seq[String]] = {
+    collect(stringNode("title", dcterms))
+  }
+
+  def serializeDctermsDescription: XmlSerializer[Seq[String]] = {
+    collect(stringNode("description", dcterms))
+  }
+}

--- a/example/src/main/scala/com/github/rvanheest/spickle/example/xml/namespace/NamespaceSerializer2.scala
+++ b/example/src/main/scala/com/github/rvanheest/spickle/example/xml/namespace/NamespaceSerializer2.scala
@@ -1,0 +1,57 @@
+package com.github.rvanheest.spickle.example.xml.namespace
+
+import com.github.rvanheest.spickle.example.xml.namespace.Namespace.Note
+import com.github.rvanheest.spickle.serializer.xml.XmlSerializer._
+
+import scala.util.Success
+import scala.xml._
+
+object NamespaceSerializer2Runner extends App {
+
+  val input = Note(
+    Seq("dc-title1", "dc-title2", "dc-title3"),
+    Seq("dcterms-title1"),
+    Seq("dcterms-description1", "dcterms-description2", "dcterms-description3")
+  )
+  println(input)
+
+  val Success(Seq(xml1)) = NamespaceSerializer2.serializeNamespacedNote.serialize(input)
+  println(new PrettyPrinter(160, 2).format(xml1))
+}
+
+object NamespaceSerializer2 {
+
+  val ns: NamespaceBinding = NamespaceBinding("ns", "http://www.github.com/rvanheest/spickle/example/namespace", TopScope)
+  val dc: NamespaceBinding = NamespaceBinding("dc", "http://purl.org/dc/elements/1.1/", TopScope)
+  val dcterms: NamespaceBinding = NamespaceBinding("dcterms", "http://purl.org/dc/terms/", TopScope)
+  val xsi: NamespaceBinding = NamespaceBinding("xsi", "http://www.w3.org/2001/XMLSchema-instance", TopScope)
+
+  val namespace: NamespaceBinding = NamespaceBinding("ns", "http://www.github.com/rvanheest/spickle/example/namespace", NamespaceBinding("xsi", "http://www.w3.org/2001/XMLSchema-instance", NamespaceBinding("dc", "http://purl.org/dc/elements/1.1/", NamespaceBinding("dcterms", "http://purl.org/dc/terms/", TopScope))))
+
+  def serializeNamespacedNote: XmlSerializer[Note] = {
+    withNamespace(namespace) {
+      attribute("schemaLocation", xsi).contramap[Note](_ => "http://www.github.com/rvanheest/spickle/example/namespace https://raw.githubusercontent.com/rvanheest/spickle/16bfbc384aaea114a32a4c60d0fdd5cbd2845c98/example/src/main/resources/namespace/schema.xsd")
+        .combine(serializeNote)
+    }
+  }
+
+  def serializeNote: XmlSerializer[Note] = {
+    branchNode("note", ns) {
+      serializeDcTitles.contramap[Note](_.dcTitle)
+        .combine(serializeDctermsTitles.contramap(_.dctermsTitle))
+        .combine(serializeDctermsDescription.contramap(_.dctermsDescription))
+    }
+  }
+
+  def serializeDcTitles: XmlSerializer[Seq[String]] = {
+    collect(stringNode("title", dc))
+  }
+
+  def serializeDctermsTitles: XmlSerializer[Seq[String]] = {
+    collect(stringNode("title", dcterms))
+  }
+
+  def serializeDctermsDescription: XmlSerializer[Seq[String]] = {
+    collect(stringNode("description", dcterms))
+  }
+}

--- a/example/src/main/scala/com/github/rvanheest/spickle/example/xml/person/PersonParser.scala
+++ b/example/src/main/scala/com/github/rvanheest/spickle/example/xml/person/PersonParser.scala
@@ -40,11 +40,11 @@ trait PersonParser {
   }
 
   def parsePerson: XmlParser[Person] = {
-    implicit val xlinkNamespace: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
+    val xlinkNamespace: NamespaceBinding = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
     for {
       // ALWAYS put the attribute parsing first, BEFORE parsing the node's content
       age <- attribute("age").toInt
-      _ <- namespaceAttribute("age").toInt
+      _ <- attribute("age", xlinkNamespace).toInt
       p <- branchNode("person") {
         for {
           pName <- stringNode("name")

--- a/example/src/main/scala/com/github/rvanheest/spickle/example/xml/person/PersonPickle.scala
+++ b/example/src/main/scala/com/github/rvanheest/spickle/example/xml/person/PersonPickle.scala
@@ -40,11 +40,11 @@ trait PersonPickle {
   }
 
   def picklePerson: XmlPickle[Person] = {
-    implicit val xlinkNamespace = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
+    val xlinkNamespace = NamespaceBinding("xlink", "http://www.w3.org/1999/xlink", TopScope)
     for {
       // ALWAYS put the attribute pickling first, BEFORE pickling the node's content
       age <- attribute("age").toInt.seq[Person](_.age)
-      _ <- namespaceAttribute("age").toInt.seq[Person](_.age)
+      _ <- attribute("age", xlinkNamespace).toInt.seq[Person](_.age)
       p <- branchNode("person") {
         for {
           pName <- stringNode("name").seq[Person](_.name)

--- a/example/src/main/scala/com/github/rvanheest/spickle/example/xml/person/PersonSerializer.scala
+++ b/example/src/main/scala/com/github/rvanheest/spickle/example/xml/person/PersonSerializer.scala
@@ -39,7 +39,7 @@ trait PersonSerializer {
 
     // ALWAYS put the attribute serializing first, BEFORE serializing the node's content
     attribute("age").fromInt.contramap[Person](_.age)
-      .combine(namespaceAttribute("age").fromInt.contramap(_.age))
+      .combine(attribute("age").fromInt.contramap(_.age))
       .combine(branchNode("person") {
         stringNode("name").contramap[Person](_.name)
           .combine(serializeAddress("address").contramap(_.address))


### PR DESCRIPTION
To support namespaces in XML parsing/serializing, the following things were added to the library:
* `node`, `emptyNode`, `stringNode` and `branchNode` got overloads with the `NamespaceBinding` as the second argument. When using these overloads, the node's name is given the prefix of the `NamespaceBinding`.
* `namespaceAttribute` is renamed to `attribute` and no longer has the implicit `NamespaceBinding`; instead it is now an overload with a second parameter containing the namespace. When using this overload, the attribute's name is given the prefix of the `NamespaceBinding`.
* A new operator `withNamespace` was added to `XmlSerializer` and `XmlPickle` that adds the actual namespace(s) to a node.
  * Note that this operator was not added to `XmlParser`. So far I haven't gotten it to work in all circumstances. The only thing it does, though, is verify that this namespace is actually present in the xml structure. This is not a critical feature to have, so for now I left it out.

Furthermore, tests were added for these new overloads and operators. Also an example was added to demonstrate the use of namespaces in **spickle**.